### PR TITLE
Remove an `is_admin` that was breaking things.

### DIFF
--- a/components/class-go-quotes.php
+++ b/components/class-go-quotes.php
@@ -80,7 +80,6 @@ class GO_Quotes
 
 	public function custom_quicktags()
 	{
-
 		if ( wp_script_is( 'quicktags' ) )
 		{
 		?>
@@ -117,7 +116,6 @@ class GO_Quotes
 	 */
 	public function render_quote( $type, $atts, $content )
 	{
-
 		//bail if no content
 		if ( is_null( $content ) )
 		{


### PR DESCRIPTION
This was preventing the code from running on admin pages and preventing the terms from being added. Holdover from before we merged the functions.

Applies to https://github.com/GigaOM/gigaom/issues/4520
