### PR TITLE
Allow both version of bold/italics, break, and underline in all quotes

### DIFF
--- a/components/class-go-quotes.php
+++ b/components/class-go-quotes.php
@@ -146,26 +146,8 @@ class GO_Quotes
 		ob_start();
 		if ( 'pullquote' == $type || 'blockquote' == $type )
 		{
-			/*
-			Allow both version of bold/italics, break, and underline.
-
-			Not adding it now, but if we want to add links, add this to the array:
-
-			'a' => array(
-				'href' => array(),
-				'title' => array()
-			),
-			 */
-			$allowed_html = array(
-				'b' => array(),
-				'br' => array(),
-				'em' => array(),
-				'i' => array(),
-				'strong' => array(),
-				'u' => array(),
-			);
 			//set some defaults
-			$wrapped_content               = '<p class="content">' . wp_kses( $content, $allowed_html) . '</p>';
+			$wrapped_content               = '<p class="content">' . wp_kses_post( $content ) . '</p>';
 			$attribution_start     = '<footer><cite>';
 			$attribution_end       = '</cite></footer>';
 			$wrapper_start         = '';
@@ -187,7 +169,7 @@ class GO_Quotes
 
 				default:
 					$quote_block_start     = '<q id="quote-' . absint( ++$this->quote_id );
-					$wrapped_content       = wp_kses( $content, $allowed_html);
+					$wrapped_content       = wp_kses_post( $content );
 					$quote_block_end       = '</q>';
 					break;
 			}//end switch
@@ -245,7 +227,7 @@ class GO_Quotes
 				}
 			}// end if
 
-			$quote_string .= ' id="quote-' . ++$this->quote_id . '">' . esc_html( $content ) . '</q>';
+			$quote_string .= ' id="quote-' . ++$this->quote_id . '">' . wp_kses_post( $content ) . '</q>';
 
 			echo $quote_string;
 		}//end else


### PR DESCRIPTION
Applies to https://github.com/GigaOM/gigaom/issues/5315

_Note there is a `<br>` after "viewpoints" in the images below as well (not really visible)._
### Pullquote:

![screen shot 2014-09-19 at 9 19 02 am](https://cloud.githubusercontent.com/assets/929375/4335767/f7f1b7fc-3fff-11e4-952c-835175a238df.png)
### Blockquote:

![screen shot 2014-09-19 at 9 22 39 am](https://cloud.githubusercontent.com/assets/929375/4335778/0e1ff4f8-4000-11e4-9532-88e6af589c88.png)
### And just to round it out, Quote:

![screen shot 2014-09-19 at 9 24 49 am](https://cloud.githubusercontent.com/assets/929375/4335809/5e44b2b6-4000-11e4-93c2-ae3db1589b81.png)
