### PR TITLE
Move social icons to a filter to remove breaking dependency on go-local-bsocial

### DIFF
--- a/components/class-go-quotes.php
+++ b/components/class-go-quotes.php
@@ -210,7 +210,7 @@ class GO_Quotes
 			$quote_permalink = get_permalink( $post->ID ) . '#quote-' . $this->quote_id;
 			//permalink
 			$links = '<a href="' . esc_url( $quote_permalink ) . '" class="goicon icon-link-circled"></a>';
-			$links = apply_filters( 'go_quotes_links', $links, $quote_permalink, $post->ID, $this->quote_id );
+			$links = apply_filters( 'go_quotes_links', $links, $quote_permalink, $post->ID );
 
 			echo '<div class="social">';
 			echo wp_kses_post( $links );


### PR DESCRIPTION
Addresses https://github.com/GigaOM/gigaom/issues/4654

Only try to show the social icons of `go-local-bsocial` is present.

New filter that lets `go-local-bsocial` add the icons in. No `go-local-bsocial` == no icons. Works on a vanilla WP install (no breaking deps)
