### PR TITLE
Add person tags on save

### DIFF
--- a/components/class-go-quotes-admin.php
+++ b/components/class-go-quotes-admin.php
@@ -206,7 +206,7 @@ class GO_Quotes_Admin
 		$this->post_id = $post_id;
 
 		$original_post_content = $content = $_POST['post_content'];
-		do_shortcode( $content );
+		do_shortcode( $post->post_content );
 
 		$this->is_save_post = FALSE;
 		$this->post_id = NULL;

--- a/components/class-go-quotes.php
+++ b/components/class-go-quotes.php
@@ -179,9 +179,9 @@ class GO_Quotes
 		);
 
 		//check if we're saving and add person terms
-		if ( isset( $atts[ 'person' ] ) && $this->is_save_post )
+		if ( isset( $atts[ 'person' ] ) && $this->admin->is_save_post )
 		{
-			wp_set_post_terms( $this->post_id, $atts[ 'person' ], $this->config( 'taxonomy' ), TRUE );
+			wp_set_post_terms( $this->admin->post_id, $atts[ 'person' ], $this->config( 'taxonomy' ), TRUE );
 			return;
 		}//end if
 


### PR DESCRIPTION
Addresses GigaOM/gigaom#6338

The current way we handle this, we need to use `$this->admin` for the term info - because we're getting here via `class-go-quotes-admin`.

Replaces https://github.com/GigaOM/go-quotes/pull/20
